### PR TITLE
Support Docker Compose for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ Ahab
 .idea
 .eggs
 .cache
+#Mongo
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM ubuntu:latest
 MAINTAINER Perseids Project "perseids@tufts.edu"
 RUN apt-get update -y
-RUN apt-get install -y python3-pip python3-dev build-essential mongodb
+RUN apt-get install -y python3-pip python3-dev build-essential mongodb netcat
 ADD ./ /app
 WORKDIR /app
 RUN ls -la
 RUN pip3 install -r requirements.txt
-ENTRYPOINT ["python3"]
-CMD ["run.py"]
+CMD ["python3", "run.py"]

--- a/README.rst
+++ b/README.rst
@@ -67,14 +67,16 @@ Run the code, installing test fixtures and with a fixed user:
 
     python runtest.py --install --loggedin
 
-Or deploy in Docker container
+Or with Docker and Docker Compose
 
 .. code-block:: shell
 
     git clone https://github.com/perseids-project/digital_milliet
     cd digital_milliet 
-    docker build -t digital_milliet_image .
-    docker run -p 5000:5000 -t -i digital_milliet_image
+    docker-compose build
+    docker-compose run web scripts/docker-setup.sh
+    docker-compose up
+    docker-compose run web scripts/docker-teardown.sh
 
 For production deployment, see Puppet manifests in the puppet subdirectory of this repository.
 

--- a/digital_milliet/docker-config.cfg
+++ b/digital_milliet/docker-config.cfg
@@ -1,0 +1,1 @@
+MONGO_HOST = 'mongo'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "5000:5000"
+    command: scripts/wait-for-mongo.sh python3 run.py
+    volumes:
+      - .:/app
+    depends_on:
+      - mongo
+  mongo:
+    image: mongo
+    volumes:
+      - ./data:/data/db

--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mv digital_milliet/config.cfg digital_milliet/config.cfg.bak
+cat digital_milliet/config.cfg.bak digital_milliet/docker-config.cfg > digital_milliet/config.cfg

--- a/scripts/docker-teardown.sh
+++ b/scripts/docker-teardown.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mv digital_milliet/config.cfg.bak digital_milliet/config.cfg

--- a/scripts/wait-for-mongo.sh
+++ b/scripts/wait-for-mongo.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+: ${MONGO_HOST:=mongo}
+: ${MONGO_PORT:=27017}
+: ${MONGO_RETRIES:=5}
+: ${MONGO_WAIT:=1}
+
+ii=1
+while [ $ii -le $MONGO_RETRIES ]
+do
+  if nc -z $MONGO_HOST $MONGO_PORT
+  then
+    exec $*
+  else
+    echo "Waiting for Mongo at $MONGO_HOST:$MONGO_PORT attempt $ii/$MONGO_RETRIES..."
+    sleep $MONGO_WAIT
+  fi
+
+  ii=$(($ii + 1))
+done
+
+exit 1


### PR DESCRIPTION
Add support for Docker Compose for development. Using Docker Compose allows someone to run the app without installing and configuring Mongo DB locally.

I couldn't easily get Flask to use environment variables for the Mongo host, so I introduced scripts to update the config file specifically for running in Docker and for removing those changes.

(I also pulled out the waiting script and put it in a [gist](https://gist.github.com/zfletch/ac468510bac4e0f0cb30fa6664df092a). It may be useful for other apps.)