### PR TITLE
Previous and next buttons on entry page

### DIFF
--- a/digital_milliet/lib/commentaries.py
+++ b/digital_milliet/lib/commentaries.py
@@ -643,4 +643,17 @@ class CommentaryHandler(object):
             comm_list = self.mongo.db.annotation.find({"tags.hasBody.chars": query}).sort([("commentary.hasBody.@id",1)])
         return self.retrieve_millietId_in_commentaries(comm_list)
 
+    def get_surrounding_identifier(self, cid):
+        """ Given a Milliet number, return the previous and next numbers available
 
+        :param cid: Milliet number
+        :type cid: string
+        :return: pair of Milliet numbers
+        :rtype: (string, string)
+        """
+
+        identifiers = self.get_milliet_identifier_list()
+        index = identifiers.index(cid)
+        previous_id = identifiers[index - 1] if index - 1 >= 0 else None
+        next_id = identifiers[index + 1] if index + 1 < len(identifiers) else None
+        return (previous_id, next_id)

--- a/digital_milliet/lib/views.py
+++ b/digital_milliet/lib/views.py
@@ -78,8 +78,10 @@ class Views(object):
         parsed_obj, auth_info = self.commentaries.get_milliet(millnum)
         if 'orig_uri' in parsed_obj:
             session['cts_uri'] = parsed_obj['orig_uri']
+        (previous_millnum, next_millnum) = self.commentaries.get_surrounding_identifier(millnum)
 
-        return render_template('commentary/read.html', obj=parsed_obj, info=auth_info, millnum=millnum)
+        return render_template('commentary/read.html', obj=parsed_obj, info=auth_info, millnum=millnum,
+            previous_millnum=previous_millnum, next_millnum=next_millnum)
 
     @OAuthHelper.oauth_required
     def delete(self):

--- a/digital_milliet/templates/commentary/read.html
+++ b/digital_milliet/templates/commentary/read.html
@@ -150,10 +150,21 @@
         </section>
     </div>
 
-
     <aside class='row' id="export">
       <div class="col-xs-12 align-right">
         <a class="btn-milliet sm" href="{{url_for('api_data_get', millnum=millnum)}}">Get JSON</a>
+      </div>
+    </aside>
+    <aside class='row' id="prev-next-links">
+      <div class="col-xs-6 text-left">
+        {% if previous_millnum %}
+          <a class="btn-milliet sm" href="/commentary/{{ previous_millnum }}">Previous</a>
+        {% endif %}
+      </div>
+      <div class="col-xs-6 text-right">
+        {% if next_millnum %}
+          <a class="btn-milliet sm" href="/commentary/{{ next_millnum }}">Next</a>
+        {% endif %}
       </div>
     </aside>
   </article>

--- a/tests/test_identifier_list.py
+++ b/tests/test_identifier_list.py
@@ -1,0 +1,32 @@
+import os
+import yaml
+from digital_milliet.digital_milliet import DigitalMilliet
+from flask import Flask
+from tests.test_dm import DigitalMillietTestCase
+
+
+class TestIdentifierList(DigitalMillietTestCase):
+    def setUp(self):
+        self.app = Flask('digital_milliet')
+        self.dm = self.make_dm(app=self.app,config_file="../tests/testconfig.cfg")
+        self.client = self.app.test_client()
+        self.fixture = os.path.join(os.path.dirname(__file__), 'dbfixture.yml')
+        self.mongo = self.dm.get_db()
+        self.setupDb()
+        self.setupSession()
+
+    def test_get_milliet_identifier_list(self):
+        with self.app.app_context():
+            expected_identifier_list = ["261", "999"]
+            identifier_list = self.dm.commentaries.get_milliet_identifier_list()
+            self.assertEqual(expected_identifier_list, identifier_list)
+
+    def test_get_surrounding_identifier(self):
+        with self.app.app_context():
+            expected_identifier_pair = (None, "999")
+            identifier_pair = self.dm.commentaries.get_surrounding_identifier("261")
+            self.assertEqual(expected_identifier_pair, identifier_pair)
+
+            expected_identifier_pair = ("261", None)
+            identifier_pair = self.dm.commentaries.get_surrounding_identifier("999")
+            self.assertEqual(expected_identifier_pair, identifier_pair)


### PR DESCRIPTION
On the `commentary/:id` page, add "Previous" and "Next" buttons which go to the previous or next page, according to the order of commentaries under "Milliet Commentary" on the `/commentary` page. Fixes https://github.com/perseids-project/digital_milliet/issues/75

---

<img width="1236" alt="screen shot 2018-03-23 at 14 25 04" src="https://user-images.githubusercontent.com/3039310/37847126-2342b17a-2ea6-11e8-85d5-b7b9d5230c8e.png">
