### PR TITLE
Include locale in URLs within application

### DIFF
--- a/digital_milliet/digital_milliet.py
+++ b/digital_milliet/digital_milliet.py
@@ -59,6 +59,14 @@ class DigitalMilliet(object):
         def get_locale():
             return g.get('lang', self.babel.default_locale)
 
+        @self.app.url_defaults
+        def set_language_code(endpoint, values):
+            lang = get_locale()
+            if 'lang' in values or lang == self.babel.default_locale:
+                return
+            if self.app.url_map.is_endpoint_expecting(endpoint, 'lang'):
+                values['lang'] = lang
+
     def get_db(self):
         return self.mongo
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -23,10 +23,12 @@ class TestRoutes(DigitalMillietTestCase, TestCase):
     def test_about(self):
         rv = self.client.get('/about').data.decode()
         self.assertIn('What is the Digital Milliet?',rv,"Doesn't appear to be the aobut.html")
+        self.assertIn('<a href="/commentary">Browse</a>',rv,"Doesn't appear to be the aobut.html")
 
     def test_fr_about(self):
         rv = self.client.get('/fr/about').data.decode()
         self.assertIn("Qu'est-ce que le Digital Milliet ?",rv,"Doesn't appear to be the aobut.html")
+        self.assertIn('<a href="/fr/commentary">Browse</a>',rv,"Doesn't appear to be the aobut.html")
 
     def test_search(self):
         rv = self.client.get('/search?in=Author&query=Xenophon').data.decode()


### PR DESCRIPTION
Using `@app.url_defaults`, add the locale in links generated with `url_for`. This means that once a user is within a locale namespace, all links in the application will continue using that namespace. This change also excludes the default locale, so when a user visits `/`, they will be linked to `/about`, not `/en/about`.