### PR TITLE
Allow multiple config files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,7 @@ Or with Docker and Docker Compose
     git clone https://github.com/perseids-project/digital_milliet
     cd digital_milliet 
     docker-compose build
-    docker-compose run web scripts/docker-setup.sh
     docker-compose up
-    docker-compose run web scripts/docker-teardown.sh
 
 For production deployment, see Puppet manifests in the puppet subdirectory of this repository.
 
@@ -87,7 +85,7 @@ path can be supplied in an argument to the DigitalMilliet Flask Application:
 
 .. code-block:: python
 
-    DigitalMilliet(app, config_file="path/to/your/config.cfg")
+    DigitalMilliet(app, config_files=["path/to/your/config.cfg"])
 
 
 The default contents of this configuration file, with explanation of each setting, is provided below:

--- a/digital_milliet/digital_milliet.py
+++ b/digital_milliet/digital_milliet.py
@@ -20,16 +20,18 @@ PERSONNA = re.compile("^\w\.\w+$")
 class DigitalMilliet(object):
     """ The Digital Milliet Web Application """
 
-    def __init__(self, app=None, config_file="config.cfg"):
+    def __init__(self, app=None, config_files=["config.cfg"]):
         self.app = None
 
         if app is not None:
             self.app = app
-            self.init_app(config_file)
+            self.init_app(config_files)
 
-    def init_app(self, config_file=None):
+    def init_app(self, config_files=[]):
 
-        self.app.config.from_pyfile(config_file, silent=False)
+        for config in config_files:
+            self.app.config.from_pyfile(config, silent=False)
+
         self.app.secret_key = self.app.config['SECRET_KEY']
         self.bower = Bower(self.app)
         self.markdown = Markdown(self.app)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: .
     ports:
       - "5000:5000"
-    command: scripts/wait-for-mongo.sh python3 run.py
+    command: scripts/wait-for-mongo.sh python3 run.py config.cfg docker-config.cfg
     volumes:
       - .:/app
     depends_on:

--- a/puppet/templates/app.wsgi.epp
+++ b/puppet/templates/app.wsgi.epp
@@ -9,4 +9,4 @@ from flask import Flask
 from digital_milliet.digital_milliet import DigitalMilliet
 
 application = Flask("digital_milliet")
-dm = DigitalMilliet(application,config_file="config.cfg")
+dm = DigitalMilliet(application,config_files=["config.cfg"])

--- a/run.py
+++ b/run.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 from flask import Flask
 from digital_milliet.digital_milliet import DigitalMilliet
+import sys
+
+config_files = ["config.cfg"]
+if len(sys.argv) > 1:
+    config_files = sys.argv[1:]
+
 app = Flask('digital_milliet')
-dm = DigitalMilliet(app, config_file="config.cfg")
+dm = DigitalMilliet(app, config_files=config_files)
 app.run(debug=True, host="0.0.0.0", port=5000)

--- a/runtest.py
+++ b/runtest.py
@@ -5,7 +5,7 @@ import yaml
 import argparse
 
 app = Flask('digital_milliet')
-dm = DigitalMilliet(app, config_file="../tests/testconfig.cfg")
+dm = DigitalMilliet(app, config_files=["../tests/testconfig.cfg"])
 mongo = dm.get_db()
 
 

--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-mv digital_milliet/config.cfg digital_milliet/config.cfg.bak
-cat digital_milliet/config.cfg.bak digital_milliet/docker-config.cfg > digital_milliet/config.cfg

--- a/scripts/docker-teardown.sh
+++ b/scripts/docker-teardown.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-mv digital_milliet/config.cfg.bak digital_milliet/config.cfg

--- a/scripts/fixdb.py
+++ b/scripts/fixdb.py
@@ -5,7 +5,7 @@ from digital_milliet.digital_milliet import DigitalMilliet
 from digital_milliet.lib.commentaries import CommentaryHandler
 
 app = Flask('digital_milliet')
-dm = DigitalMilliet(app, config_file="config.cfg")
+dm = DigitalMilliet(app, config_files=["config.cfg"])
 person = {
     "@id": "http://data.perseus.org/sosol/users/Val%C3%A9rie%20Toillon",
     "type": 'Person',

--- a/scripts/fixdups.py
+++ b/scripts/fixdups.py
@@ -5,7 +5,7 @@ from digital_milliet.digital_milliet import DigitalMilliet
 from digital_milliet.lib.author_builder import AuthorBuilder
 
 app = Flask('digital_milliet')
-dm = DigitalMilliet(app, config_file="config.cfg")
+dm = DigitalMilliet(app, config_files=["config.cfg"])
 person = {
     "@id": "http://data.perseus.org/sosol/users/Val%C3%A9rie%20Toillon",
     "type": 'Person',

--- a/tests/test_author_different_collection.py
+++ b/tests/test_author_different_collection.py
@@ -13,7 +13,7 @@ class TestDifferentAuthorCollection(TestRoutes):
         self.app = Flask('digital_milliet')
         self.dm = self.make_dm(
             app=self.app,
-            config_file="../tests/testconfig_collection_authors.cfg")
+            config_files=["../tests/testconfig_collection_authors.cfg"])
         self.client = self.app.test_client()
         self.fixture = os.path.join(os.path.dirname(__file__), 'dbfixture.yml')
         self.mongo = self.dm.get_db()

--- a/tests/test_dm.py
+++ b/tests/test_dm.py
@@ -14,7 +14,7 @@ class DigitalMillietTestCase(TestCase):
     def setUp(self):
         self.app = Flask('digital_milliet')
         self.dm = self.make_dm(app=self.app,
-                               config_file="../tests/testconfig.cfg")
+                               config_files=["../tests/testconfig.cfg"])
         self.client = self.app.test_client()
         self.fixture = os.path.join(os.path.dirname(__file__), 'dbfixture.yml')
         self.mongo = self.dm.get_db()

--- a/tests/test_identifier_list.py
+++ b/tests/test_identifier_list.py
@@ -9,7 +9,7 @@ class TestIdentifierList(DigitalMillietTestCase):
     def setUp(self):
         self.app = Flask('digital_milliet')
         self.dm = self.make_dm(app=self.app,
-                               config_file="../tests/testconfig.cfg")
+                               config_files=["../tests/testconfig.cfg"])
         self.client = self.app.test_client()
         self.fixture = os.path.join(os.path.dirname(__file__), 'dbfixture.yml')
         self.mongo = self.dm.get_db()

--- a/tests/test_tag_search.py
+++ b/tests/test_tag_search.py
@@ -9,7 +9,7 @@ class TestTagSearch(DigitalMillietTestCase):
     def setUp(self):
         self.app = Flask('digital_milliet')
         self.dm = self.make_dm(app=self.app,
-                               config_file="../tests/testconfig.cfg")
+                               config_files=["../tests/testconfig.cfg"])
         self.client = self.app.test_client()
         self.fixture = os.path.join(
             os.path.dirname(__file__),


### PR DESCRIPTION
Allow the app to be configured with multiple configuration files. Also allow these files to passed in as command line arguments to `run.py`.

Remove the Docker setup scrips because they're not necessary any more.