### PR TITLE
Configure application with environment

### DIFF
--- a/digital_milliet/digital_milliet.py
+++ b/digital_milliet/digital_milliet.py
@@ -12,6 +12,7 @@ from digital_milliet.lib.commentaries import CommentaryHandler
 from digital_milliet.lib.views import Views
 from digital_milliet.lib.catalog import Catalog
 from digital_milliet.lib.mirador import Mirador
+from digital_milliet.lib.configuration import Configuration
 
 import re
 PERSONNA = re.compile("^\w\.\w+$")
@@ -20,17 +21,20 @@ PERSONNA = re.compile("^\w\.\w+$")
 class DigitalMilliet(object):
     """ The Digital Milliet Web Application """
 
-    def __init__(self, app=None, config_files=["config.cfg"]):
+    def __init__(self, app=None, config_files=["config.cfg"], config_objects=[]):
         self.app = None
 
         if app is not None:
             self.app = app
-            self.init_app(config_files)
+            self.init_app(config_files, config_objects)
 
-    def init_app(self, config_files=[]):
+    def init_app(self, config_files=[], config_objects=[]):
 
         for config in config_files:
             self.app.config.from_pyfile(config, silent=False)
+
+        for config in config_objects:
+            self.app.config.from_object(config)
 
         self.app.secret_key = self.app.config['SECRET_KEY']
         self.bower = Bower(self.app)

--- a/digital_milliet/docker-config.cfg
+++ b/digital_milliet/docker-config.cfg
@@ -1,1 +1,0 @@
-MONGO_HOST = 'mongo'

--- a/digital_milliet/lib/configuration.py
+++ b/digital_milliet/lib/configuration.py
@@ -1,0 +1,9 @@
+from flask import Flask
+from flask_env import MetaFlaskEnv
+
+
+class Configuration(metaclass=MetaFlaskEnv):
+    ENV_PREFIX = "DIGMILL_"
+
+app = Flask(__name__)
+app.config.from_object(Configuration)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,13 @@ services:
     build: .
     ports:
       - "5000:5000"
-    command: scripts/wait-for-mongo.sh python3 run.py config.cfg docker-config.cfg
+    command: scripts/wait-for-mongo.sh python3 run.py config.cfg ENV
     volumes:
       - .:/app
     depends_on:
       - mongo
+    environment:
+      - DIGMILL_MONGO_HOST=mongo
   mongo:
     image: mongo
     volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ Flask-Markdown
 MyCapytain==2.0.0b8
 PyYaml
 setuptools==36.5.0
+Flask-Env==1.0.1

--- a/run.py
+++ b/run.py
@@ -1,12 +1,24 @@
 #!/usr/bin/env python
 from flask import Flask
 from digital_milliet.digital_milliet import DigitalMilliet
+from digital_milliet.lib.configuration import Configuration
 import sys
 
 config_files = ["config.cfg"]
 if len(sys.argv) > 1:
     config_files = sys.argv[1:]
 
+config_files = []
+config_objects = []
+for arg in sys.argv[1:]:
+    if arg == "ENV":
+        config_objects.append(Configuration)
+    else:
+        config_files.append(arg)
+
+if len(config_files) == 0:
+    config_files = ["config.cfg"]
+
 app = Flask('digital_milliet')
-dm = DigitalMilliet(app, config_files=config_files)
+dm = DigitalMilliet(app, config_files, config_objects)
 app.run(debug=True, host="0.0.0.0", port=5000)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ setup(
         "Flask-PyMongo==0.3.1",
         "Flask-Markdown",
         "MyCapytain==2.0.0b8",
-        "PyYaml"
+        "PyYaml",
+        "setuptools==36.5.0",
+        "Flask-Env==1.0.1"
     ],
     setup_requires=[
     ],


### PR DESCRIPTION
Using the `Flask-Env` library, allow overwriting configuration files with environment variables. This is done by passing `ENV` as an argument to `run.py` and putting `DIGMILL_` before a particular configuration option.

For example: `env DIGMILL_MONGO_HOST=mongo python run.py config.cfg ENV` will use the configuration specified in `config.cfg` but overwrite the `MONGO_HOST` option.

I think this is the ideal solution. It provides a lot of flexibility without making major changes, since:

* deployment scripts don't have to be changed to use the environment instead of a `.cfg` files
* the application can be deployed with environment variable configuration if it needs to be (for example, any PaaS that requires [12 factor apps](https://12factor.net/))
* the default configuration is shared in both cases.